### PR TITLE
Make isPrime return false for nonpositive numbers

### DIFF
--- a/Data/Numbers/Primes.hs
+++ b/Data/Numbers/Primes.hs
@@ -52,14 +52,14 @@ wheelSieve k = reverse ps ++ map head (sieve p (cycle ns))
 {-# SPECIALISE wheelSieve :: Int -> [Integer] #-}
 
 -- |
--- Checks whether a given positive number is prime.
+-- Checks whether a given number is prime.
 -- 
 -- This function uses trial division to check for divisibility with
 -- all primes below the square root of the given number. It is
 -- impractical for numbers with a very large smallest prime factor.
 -- 
 isPrime :: Integral int => int -> Bool
-isPrime n = primeFactors n == [n]
+isPrime n = n > 1 && primeFactors n == [n]
 
 {-# SPECIALISE isPrime :: Int     -> Bool #-}
 {-# SPECIALISE isPrime :: Integer -> Bool #-}


### PR DESCRIPTION
I've been using this package for some problems on Project Euler and I just had a bug in my code which boiled down to isPrime returning true for zero. I think it's more reasonable to return False (or alternatively call error) rather than letting this function return wrong answers (even if the doc says it's only defined for positive numbers).
